### PR TITLE
update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ How to Use
 
 4. Download and install RenderDoc from http://renderdoc.org/builds  
    The stable build v0.27 of 2016-02-16 is recommended.
-  
+
 5. From within the UE4 Editor, enable both the RenderDocPlugin and the RenderDocLoaderPlugin, as shown below. Note that you will need to restart the UE4 Editor for these changes to take place.  
    ![](doc/img/howto-plugin_menu.jpg)   ![](doc/img/howto-enable.jpg)
 
@@ -28,10 +28,13 @@ How to Use
    If unable to locate one, you will be prompted to locate RenderDoc manually through a dialog window.  
    The plugin will remember the RenderDoc location until it is no longer valid.
 
-7. After the plugin has been loaded successfully, you should have two new buttons in the top-right corner of your viewport.  
+7. After the plugin has been loaded successfully, you should have two new buttons in the top-right corner of your Level Editor viewport.  
    The left-most button (see below) will capture the next frame and launch the RenderDoc UI to inspect the frame.  
    The right-most button has some configuration options.  
    ![](doc/img/howto-capture.jpg)
+
+8. Alternatively, the console command `RenderDoc.CaptureFrame` can also be used for capturing a frame. This is particularly useful when in PIE (Play-in-Editor) mode or when in Game mode, as the Level Editor viewport UI is omitted during gameplay.
+
 
 
 For Advanced Users

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ How to Use
 3. In order to build the plugin, make sure to run UE4's `Generate Project Files` to register the plugin source code with Unreal Build Tool.
 
 4. Download and install RenderDoc from http://renderdoc.org/builds  
-   The stable build v0.27 of 2016-02-16 is recommended.
+   The stable build v0.29 of 2016-05-08 is recommended.
 
 5. From within the UE4 Editor, enable both the RenderDocPlugin and the RenderDocLoaderPlugin, as shown below. Note that you will need to restart the UE4 Editor for these changes to take place.  
    ![](doc/img/howto-plugin_menu.jpg)   ![](doc/img/howto-enable.jpg)

--- a/RenderDocAPI/renderdoc_app.h
+++ b/RenderDocAPI/renderdoc_app.h
@@ -1,7 +1,7 @@
 /******************************************************************************
  * The MIT License (MIT)
  * 
- * Copyright (c) 2015 Baldur Karlsson
+ * Copyright (c) 2015-2016 Baldur Karlsson
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,21 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// Constants not used directly in below API
+
+// This is a GUID/magic value used for when applications pass a path where shader debug
+// information can be found to match up with a stripped shader.
+// the define can be used like so: const GUID RENDERDOC_ShaderDebugMagicValue = RENDERDOC_ShaderDebugMagicValue_value
+#define RENDERDOC_ShaderDebugMagicValue_struct { 0xeab25520, 0x6670, 0x4865, 0x84, 0x29, 0x6c, 0x8, 0x51, 0x54, 0x00, 0xff }
+
+// as an alternative when you want a byte array (assuming x86 endianness):
+#define RENDERDOC_ShaderDebugMagicValue_bytearray { 0x20, 0x55, 0xb2, 0xea, 0x70, 0x66, 0x65, 0x48, 0x84, 0x29, 0x6c, 0x8, 0x51, 0x54, 0x00, 0xff }
 	
+// truncated version when only a uint64_t is available (e.g. Vulkan tags):
+#define RENDERDOC_ShaderDebugMagicValue_truncated 0x48656670eab25520ULL
+
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // RenderDoc capture options
 // 
@@ -445,10 +459,17 @@ typedef uint32_t (RENDERDOC_CC *pRENDERDOC_EndFrameCapture)(RENDERDOC_DevicePoin
 // instead of 1.0.0. You can check this with the GetAPIVersion entry point
 typedef enum
 {
-	eRENDERDOC_API_Version_1_0_0 = 10000, // RENDERDOC_API_1_0_0 = 1 000 000
+	eRENDERDOC_API_Version_1_0_0 = 10000, // RENDERDOC_API_1_0_0 = 1 00 00
+	eRENDERDOC_API_Version_1_0_1 = 10001, // RENDERDOC_API_1_0_1 = 1 00 01
 } RENDERDOC_Version;
 
-// eRENDERDOC_API_Version_1_0_0
+// API version changelog:
+//
+// 1.0.0 - initial release
+// 1.0.1 - Bugfix: IsFrameCapturing() was returning false for captures that were triggered
+//         by keypress or TriggerCapture, instead of Start/EndFrameCapture.
+
+// eRENDERDOC_API_Version_1_0_1
 typedef struct
 {
 	pRENDERDOC_GetAPIVersion              GetAPIVersion;
@@ -484,7 +505,9 @@ typedef struct
 	pRENDERDOC_StartFrameCapture          StartFrameCapture;
 	pRENDERDOC_IsFrameCapturing           IsFrameCapturing;
 	pRENDERDOC_EndFrameCapture            EndFrameCapture;
-} RENDERDOC_API_1_0_0;
+} RENDERDOC_API_1_0_1;
+
+typedef RENDERDOC_API_1_0_1 RENDERDOC_API_1_0_0;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 // RenderDoc API entry point


### PR DESCRIPTION
Hi there,

Another quick bug-fix, this time related to the order upon which the viewport to be intercepted/captured is chosen. This should result in the intended user behavior for pretty much all cases, except when attempting to capture from a "PIE-then-Eject" viewport.

I have also updated the documentation to favor RenderDoc v0.29.

That's all for now.
