### PR TITLE
Fixed plugin build for UE4.15

### DIFF
--- a/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginAboutWindow.cpp
+++ b/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginAboutWindow.cpp
@@ -22,13 +22,13 @@
 * THE SOFTWARE.
 ******************************************************************************/
 
-#include "RenderDocPluginPrivatePCH.h"
-
 #if WITH_EDITOR
+
+// Starting from UE4.15, this must be the first include file...
+#include "RenderDocPluginAboutWindow.h"
 
 #include "Editor.h"
 #include "RenderDocPluginStyle.h"
-#include "RenderDocPluginAboutWindow.h"
 
 #define LOCTEXT_NAMESPACE "RenderDocPluginAboutWindow"
 

--- a/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginCommands.cpp
+++ b/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginCommands.cpp
@@ -22,10 +22,9 @@
 * THE SOFTWARE.
 ******************************************************************************/
 
-#include "RenderDocPluginPrivatePCH.h"
-
 #if WITH_EDITOR
 
+// Starting from UE4.15, this must be the first include file...
 #include "RenderDocPluginCommands.h"
 
 #define LOCTEXT_NAMESPACE "RenderDocPluginSettingsEditor"

--- a/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginLoader.cpp
+++ b/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginLoader.cpp
@@ -23,8 +23,9 @@
 * THE SOFTWARE.
 ******************************************************************************/
 
-#include "RenderDocPluginPrivatePCH.h"
+// Starting from UE4.15, this must be the first include file...
 #include "RenderDocPluginLoader.h"
+
 #include "RenderDocPluginModule.h"
 
 #include "Internationalization.h"

--- a/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginLoader.cpp
+++ b/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginLoader.cpp
@@ -26,6 +26,8 @@
 // Starting from UE4.15, this must be the first include file...
 #include "RenderDocPluginLoader.h"
 
+#include "WindowsHWrapper.h"
+
 #include "RenderDocPluginModule.h"
 
 #include "Internationalization.h"

--- a/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginModule.cpp
+++ b/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginModule.cpp
@@ -25,6 +25,8 @@
 // Starting from UE4.15, this must be the first include file...
 #include "RenderDocPluginModule.h"
 
+#include "WindowsHWrapper.h"
+
 #include "Internationalization.h"
 #include "RendererInterface.h"
 

--- a/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginModule.cpp
+++ b/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginModule.cpp
@@ -22,7 +22,7 @@
 * THE SOFTWARE.
 ******************************************************************************/
 
-#include "RenderDocPluginPrivatePCH.h"
+// Starting from UE4.15, this must be the first include file...
 #include "RenderDocPluginModule.h"
 
 #include "Internationalization.h"

--- a/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginNotification.cpp
+++ b/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginNotification.cpp
@@ -22,11 +22,11 @@
 * THE SOFTWARE.
 ******************************************************************************/
 
-#include "RenderDocPluginPrivatePCH.h"
-
 #if WITH_EDITOR
 
+// Starting from UE4.15, this must be the first include file...
 #include "RenderDocPluginNotification.h"
+
 #include "SNotificationList.h"
 #include "NotificationManager.h"
 

--- a/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginStyle.cpp
+++ b/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginStyle.cpp
@@ -22,11 +22,11 @@
 * THE SOFTWARE.
 ******************************************************************************/
 
-#include "RenderDocPluginPrivatePCH.h"
-
 #if WITH_EDITOR
 
+// Starting from UE4.15, this must be the first include file...
 #include "RenderDocPluginStyle.h"
+
 #include "SlateStyle.h"
 #include "IPluginManager.h"
 

--- a/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginToolbar.cpp
+++ b/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginToolbar.cpp
@@ -22,9 +22,10 @@
 * THE SOFTWARE.
 ******************************************************************************/
 
-#include "RenderDocPluginPrivatePCH.h"
-
 #if WITH_EDITOR
+
+// Starting from UE4.15, this must be the first include file...
+#include "RenderDocPluginToolbar.h"
 
 #include "Engine.h"
 #include "Editor.h"
@@ -33,7 +34,6 @@
 #include "Editor/UnrealEd/Public/SViewportToolBarComboMenu.h"
 #include "RenderDocPluginStyle.h"
 #include "RenderDocPluginCommands.h"
-#include "RenderDocPluginToolbar.h"
 #include "RenderDocPluginModule.h"
 #include "RenderDocPluginAboutWindow.h"
 


### PR DESCRIPTION
Hi there,

Here is a fix that allows the plugin to be build under the recently released UE 4.15.x.

I'd also suggest you create a UE4.15 tag for this commit as well, as these changes are incompatible with older engine versions.

Cheers!