### PR TITLE
CoInitialize needs to be called before GetOpenFileName.

### DIFF
--- a/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginLoader.cpp
+++ b/RenderDocPlugin/Source/RenderDocPlugin/Private/RenderDocPluginLoader.cpp
@@ -136,7 +136,7 @@ void FRenderDocPluginLoader::Initialize()
 		FString RenderdocPath;
 		// TODO: rework the logic here by improving error checking and reporting
 		IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
-		if (DesktopPlatform)
+		if (DesktopPlatform && FWindowsPlatformMisc::CoInitialize())
 		{
 			FString Filter = TEXT("Renderdoc executable|renderdocui.exe");
 			TArray<FString> OutFiles;


### PR DESCRIPTION

Due to undefined nature of static object initialization order, CoInitialize does not always get called before GetOpenFileName.